### PR TITLE
Fixed a bug in getFe method

### DIFF
--- a/SloshingMatrix/src/Equation_SloshingMatrix.java
+++ b/SloshingMatrix/src/Equation_SloshingMatrix.java
@@ -54,7 +54,7 @@ public class Equation_SloshingMatrix implements SecondDerivative_SloshingMatrix 
 
     // Calculate Fe
     public double getFe(double t){
-        return -m* (Math.pow(OMEGA, 2)) *(Math.sin(OMEGA*t));
+        return -m* (OMEGA*OMEGA)* A *(Math.sin(OMEGA*t));
     }
     
 


### PR DESCRIPTION
In getFe method, Amplitude of vibration (A) was missing.